### PR TITLE
Update Install-RootCA.ps1

### DIFF
--- a/images/win/scripts/Installers/Install-RootCA.ps1
+++ b/images/win/scripts/Installers/Install-RootCA.ps1
@@ -46,9 +46,7 @@ function Import-SSTFromWU {
     # Serialized Certificate Store File
     $sstFile = "$env:TEMP\roots.sst"
     # Generate SST from Windows Update
-    $result = Invoke-WithRetry `
-        -Command { certutil.exe -generateSSTFromWU $sstFile }
-        -BreakCondition {$LASTEXITCODE -eq 0}
+    $result = Invoke-WithRetry { certutil.exe -generateSSTFromWU $sstFile } {$LASTEXITCODE -eq 0}
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[Error]: failed to generate $sstFile sst file`n$result"
         exit $LASTEXITCODE


### PR DESCRIPTION
added retry behaviour to certutil.exe -generateSSTFromWU

# Description
Improves the generateSSTFromWU task in Install-RootCA with a retry behaviour. It happend multiple times that Install-RootCA.ps1 exited with the following eror
```
=> vhd: Provisioning with powershell script: C:\virtual-environments\images\win/scripts/Installers/Install-RootCA.ps1
    vhd: Certificates without CERT_NOT_BEFORE_FILETIME_PROP_ID property
    vhd: Subject: CN=Microsoft Root Certificate Authority, DC=microsoft, DC=com
    vhd: Subject: CN=Thawte Timestamping CA, OU=Thawte Certification, O=Thawte, L=Durbanville, S=Western Cape, C=ZA
    vhd: Subject: CN=Microsoft Root Authority, OU=Microsoft Corporation, OU=Copyright (c) 1997 Microsoft Corp.
    vhd: Subject: CN=Symantec Enterprise Mobile Root for Microsoft, O=Symantec Corporation, C=US
    vhd: Subject: CN=Microsoft Root Certificate Authority 2011, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
    vhd: Subject: CN=Microsoft Authenticode(tm) Root Authority, O=MSFT, C=US
    vhd: Subject: CN=Microsoft Root Certificate Authority 2010, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
    vhd: Subject: CN=Microsoft ECC TS Root Certificate Authority 2018, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
    vhd: Subject: OU=Copyright (c) 1997 Microsoft Corp., OU=Microsoft Time Stamping Service Root, OU=Microsoft Corporation, O=Microsoft Trust Network
    vhd: Subject: OU="NO LIABILITY ACCEPTED, (c)97 VeriSign, Inc.", OU=VeriSign Time Stamping Service Root, OU="VeriSign, Inc.", O=VeriSign Trust Network
    vhd: Subject: CN=Microsoft ECC Product Root Certificate Authority 2018, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
    vhd: Subject: CN=DigiCert Global Root G2, OU=www.digicert.com, O=DigiCert Inc, C=US
    vhd: Subject: CN=GlobalSign, O=GlobalSign, OU=GlobalSign Root CA - R3
    vhd: Subject: CN=AAA Certificate Services, O=Comodo CA Limited, L=Salford, S=Greater Manchester, C=GB
    vhd: Subject: OU=Starfield Class 2 Certification Authority, O="Starfield Technologies, Inc.", C=US
    vhd: Subject: CN=DigiCert Global Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
    vhd: Subject: CN=DigiCert High Assurance EV Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
    vhd: Subject: OU=Go Daddy Class 2 Certification Authority, O="The Go Daddy Group, Inc.", C=US
    vhd: Subject: CN=Certum Trusted Network CA, OU=Certum Certification Authority, O=Unizeto Technologies S.A., C=PL
    vhd: Subject: CN=DigiCert Assured ID Root CA, OU=www.digicert.com, O=DigiCert Inc, C=US
    vhd: [Error]: failed to generate C:\Users\packer\AppData\Local\Temp\roots.sst sst file
    vhd: Gateway timeout (504). 0x801901f8 (-2145844744 HTTP_E_STATUS_GATEWAY_TIMEOUT) -- http://ctldl.windowsupdate.com/msdownload/update/v3/static/trustedr/en/de010808e41ec41930d44095f8fe596b582c8ca2.crt CertUtil: -generateSSTFromWU command FAILED: 0x801901f8 (-2145844744 HTTP_E_STATUS_GATEWAY_TIMEOUT) CertUtil: Gateway timeout (504).
````
The build machine runs in azure so network issues shouldn't be an issue. I like to add a retry behaviour so the task is more stable.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
